### PR TITLE
susepaste: Fix parsing of returned Location header

### DIFF
--- a/script/susepaste
+++ b/script/susepaste
@@ -121,7 +121,7 @@ URL="`
 curl -v -F "$TYPE=$INPUT" -F "title=$TITLE"  -F "expire=$EXPIRE"   \
         -F "name=$NICK"   -F "submit=submit" -F "lang=$SYNTAX"     \
 	$API_KEY                                                   \
-        ${SCHEMA}://susepaste.org 2>&1 | sed -n 's|<\ Location:\ ||p' `"
+        ${SCHEMA}://susepaste.org 2>&1 | sed -n 's|<\ [lL]ocation:\ ||p' `"
 
 # Check the results and inform the user
 

--- a/script/susepaste-screenshot
+++ b/script/susepaste-screenshot
@@ -96,7 +96,7 @@ URL="`
 curl -v -F "file=@$TMP" -F "title=$TITLE"  -F "expire=$EXPIRE"     \
         -F "name=$NICK" -F "submit=submit" -F "lang=image"         \
         $API_KEY                                                   \
-        http://susepaste.org 2>&1 | sed -n 's|<\ Location:\ ||p' `"
+        http://susepaste.org 2>&1 | sed -n 's|<\ [lL]ocation:\ ||p' `"
 
 rm -f "$TMP"
 


### PR DESCRIPTION
susepaste.org by now returns the header as 'location: ' , not 'Location:'; let's accept both cases by this script