### PR TITLE
Retire susepaste.org

### DIFF
--- a/script/susepaste
+++ b/script/susepaste
@@ -128,7 +128,6 @@ curl -v -F "$TYPE=$INPUT" -F "title=$TITLE"  -F "expire=$EXPIRE"   \
 if expr "$URL" : "^${SCHEMA}://paste.opensuse.org/[0-9a-f]\+" > /dev/null; then
 	ID="`echo "$URL" | sed 's|^'"${SCHEMA}"'://paste.opensuse.org/\([0-9a-f]\+\)[^0-9a-f]*|\1|'`"
 	echo "Pasted as:"
-	echo "   ${SCHEMA}://susepaste.org/$ID"
 	echo "   ${SCHEMA}://paste.opensuse.org/$ID"
 	if [ -x /usr/bin/xclip ]; then
 		echo "${SCHEMA}://paste.opensuse.org/$ID" | xclip -selection XA_CLIPBOARD

--- a/script/susepaste-screenshot
+++ b/script/susepaste-screenshot
@@ -105,7 +105,6 @@ rm -f "$TMP"
 if expr "$URL" : "^http://paste.opensuse.org/[0-9a-f]\+" > /dev/null; then
 	ID="`echo "$URL" | sed 's|^http://paste.opensuse.org/\([0-9a-f]\+\)[^0-9a-f]*|\1|'`"
 TEXT="Pasted as:
-   http://susepaste.org/$ID
    http://paste.opensuse.org/$ID"
 	if [ -x /usr/bin/xclip ]; then
 		echo "http://paste.opensuse.org/$ID" | xclip -selection XA_CLIPBOARD

--- a/script/susepaste-screenshot.1
+++ b/script/susepaste-screenshot.1
@@ -7,10 +7,8 @@ susepaste-screenshot \- paste screenshot on openSUSE Paste
 .SH DESCRIPTION
 .PP
 Paste screenshot of selected window to the openSUSE pastebin site, namely
-http://susepaste.org and http://paste.opensuse.org These links are
-interchangeable, both sites are the same server, so you can use either one of
-them. After taking screenshot, URL will be copied to the clipboard and
-displayed in new window.
+https://paste.opensuse.org . After taking screenshot, URL will be copied to the
+clipboard and displayed in new window.
 .PP
 Options can be changed in ~/.susepaste configuration file as variables or
 specified as arguments.

--- a/script/susepaste.1
+++ b/script/susepaste.1
@@ -6,11 +6,10 @@ susepaste \- paste text on openSUSE Paste
 [\fIoptions\fR] [\fIFILE\fR]
 .SH DESCRIPTION
 .PP
-Paste some text to the openSUSE pastebin site, namely http://susepaste.org and
-http://paste.opensuse.org These links are interchangeable, both sites are the
-same server, so you can use either one of them.  If no argument present, it
-will read the text from standard input. Otherwise it will paste content of the
-file. After pasting, it will print out URL.
+Paste some text to the openSUSE pastebin site, namely
+https://paste.opensuse.org . If no argument present, it will read the text from
+standard input. Otherwise it will paste content of the file. After pasting, it
+will print out URL.
 .PP
 Options can be changed in ~/.susepaste configuration file as variables or
 specified as arguments.

--- a/system/application/config/config.php
+++ b/system/application/config/config.php
@@ -249,7 +249,7 @@ $config['sess_match_useragent']	= FALSE;
 |
 */
 $config['cookie_prefix']	= "cookie";
-$config['cookie_domain']	= ".susepaste.org";
+$config['cookie_domain']	= ".opensuse.org";
 $config['cookie_path']		= "/";
 
 /*


### PR DESCRIPTION
The utility still prints links to the old domain name, e.g. https://susepaste.org/747860428c37, the content of which will say

	" This service is now obsolete. New service has been setup and is
	available at https://paste.opensuse.org.

Remove all references to susepaste.org.