### PR TITLE
Add info on posting an image

### DIFF
--- a/script/susepaste.1
+++ b/script/susepaste.1
@@ -95,6 +95,7 @@ values are:
      \fIhq9plus\fR          HQ9+
      \fIhtml4strict\fR      HTML
      \fIicon\fR             Icon
+     \fIimage\fR            Image (png, jpg)
      \fIini\fR              INI
      \fIinno\fR             Inno
      \fIintercal\fR         INTERCAL
@@ -237,6 +238,10 @@ How to post list of your usb devices:
 How to post susepaste that will last six hours:
 
      \fBsusepaste -t "openSUSE paste" -e "360" -f "bash" `which susepaste`\fR
+
+How to post an image that will last three hours:
+
+     \fBsusepaste -t "openSUSE image" -e "180" -f "image" example.png\fR
 
 .SH COPYRIGHT
 Copyright (C) 2010 by Michal Hrusecky <Michal@Hrusecky.net>


### PR DESCRIPTION
Import downstream patch:

```
Sat Dec  4 03:12:56 UTC 2021 - malcolmlewis@opensuse.org

- Add 0002-susepaste-add-image-paste-info.patch: Add info on
  posting an image to susepaste in the man page, (boo#1193400).
```