### PR TITLE
Repair susepaste-screenshot

### DIFF
--- a/script/susepaste-screenshot
+++ b/script/susepaste-screenshot
@@ -98,11 +98,11 @@ URL='https://paste.opensuse.org'
 OUTURL="$(
 curl    -F "file=@$TMP" -F "title=$TITLE"  -F "expire=$EXPIRE"     \
         -F "name=$NICK" -F "submit=submit" -F "lang=image"         \
-	-sSL                                                       \
+        -sLH 'Accept: application/json'                            \
         $API_KEY                                                   \
-	$URL                                                       \
-	| sed -En "s|^.*\"($URL/pastes/[0-9a-f]+)\".*$|\1|p"       \
-	)"
+        $URL                                                       \
+        | jq -r '.["human_url"]'                                   \
+        )"
 
 rm "$TMP"
 

--- a/script/susepaste-screenshot
+++ b/script/susepaste-screenshot
@@ -4,6 +4,7 @@
  #                                                                            #
  # SUSE Paste script                                                          #
  #                                                                            #
+ # Copyright (C) 2010-2024 openSUSE Contributors                              #
  # Copyright (C) 2007-2010 by Michal Hrusecky <Michal@Hrusecky.net>           #
  #                                                                            #
  # This program is free software: you can redistribute it and/or modify       #
@@ -92,29 +93,33 @@ fi
 TMP="`mktemp --tmpdir XXXXXXXX.jpg`"
 import -window $WINDOW -limit disk 500KiB -compress JPEG "$TMP" > /dev/null 2> /dev/null
 
-URL="`
-curl -v -F "file=@$TMP" -F "title=$TITLE"  -F "expire=$EXPIRE"     \
-        -F "name=$NICK" -F "submit=submit" -F "lang=image"         \
-        $API_KEY                                                   \
-        http://paste.opensuse.org 2>&1 | sed -n 's|<\ [lL]ocation:\ ||p' `"
+URL='https://paste.opensuse.org'
 
-rm -f "$TMP"
+OUTURL="$(
+curl    -F "file=@$TMP" -F "title=$TITLE"  -F "expire=$EXPIRE"     \
+        -F "name=$NICK" -F "submit=submit" -F "lang=image"         \
+	-sSL                                                       \
+        $API_KEY                                                   \
+	$URL                                                       \
+	| sed -En "s|^.*\"($URL/pastes/[0-9a-f]+)\".*$|\1|p"       \
+	)"
+
+rm "$TMP"
 
 # Check the results and inform the user
 
-if expr "$URL" : "^http://paste.opensuse.org/[0-9a-f]\+" > /dev/null; then
-	ID="`echo "$URL" | sed 's|^http://paste.opensuse.org/\([0-9a-f]\+\)[^0-9a-f]*|\1|'`"
+if [ -n "$OUTURL" ]; then
 TEXT="Pasted as:
-   http://paste.opensuse.org/$ID"
+   $OUTURL"
 	if [ -x /usr/bin/xclip ]; then
-		echo "http://paste.opensuse.org/$ID" | xclip -selection XA_CLIPBOARD
+		echo "$OUTURL" | xclip -selection clipboard
 		TEXT="$TEXT
 Link is also in your clipboard."
 	fi
 else
 	TEXT="Paste failed :-("
 fi
-if [ "`which zenity`" ]; then
+if command -v zenity >/dev/null; then
 	zenity --info --title="openSUSE Paste" --text="$TEXT"
 else
 	echo "$TEXT" | xmessage -file -


### PR DESCRIPTION
- Use https as paste.opensuse.org redirects there using 301
- Move URL to variable to avoid redundant code
- Enable curl to follow redirects, as new paste.o.o redirects further after POSTing
- Correct patterns to parse output from new paste.o.o and to fetch the resulting paste URL again
- Reduce complicated parsing logic to single sed call for sanity
- Use correct clipboard specificer, XA_CLIPBOARD does not make the entry appear in my clipboard
- Test zenity without printing a useless and misleading "which" error if it is not found
- Don't force delete file which is expected to exist as to not cover up errors with creation of the file

This is still rather ugly, but at least makes it operational again (at least on X11...).